### PR TITLE
Add tapAndCapture helper and OpenAI screenshot flow

### DIFF
--- a/andy.zig
+++ b/andy.zig
@@ -117,6 +117,13 @@ pub const Andy = struct {
         }
     }
 
+    pub fn tapAndCapture(self: Andy, element: ui.UI, out_path: []const u8) !void {
+        try self.tap(element);
+        // allow UI changes to settle before capturing
+        std.time.sleep(2_000_000_000);
+        try self.screenshot(out_path);
+    }
+
     fn exec_adb(self: Andy, args: []const []const u8) !void {
         var argv = std.ArrayList([]const u8).init(self.allocator);
         defer argv.deinit();

--- a/main.zig
+++ b/main.zig
@@ -1,24 +1,40 @@
 const std = @import("std");
 const andy = @import("andy.zig");
+const openai = @import("openai.zig");
 
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
+    const api_key = std.os.getenv("OAI_POKEBOT") orelse return error.MissingApiKey;
+    const model_id = "gpt-4o";
+
     var device = try andy.Andy.init(allocator);
     defer device.deinit();
 
-    // TODO: if start screen, recognize, and then tap
-    // maybe move tap to a generic tap
+    // helper to send screenshot to OpenAI and print description
+    fn describe(alloc: std.mem.Allocator, path: []const u8) !void {
+        var resp = try openai.chat_multi(alloc, api_key, model_id,
+            "What is in the image?", path);
+        if (resp.choices.len > 0) {
+            std.debug.print("{s}\n", .{resp.choices[0].message.content});
+        }
+    }
 
-    // TODO: maybe add sleep to tap
     std.time.sleep(2_000_000_000);
-    try device.tap(.BattleBtn);
-    std.time.sleep(5_000_000_000); // 5 seconds (in ns)
-    try device.tap(.VersusBtn);
+    try device.tapAndCapture(.BattleBtn, "cap_battle.png");
+    try describe(allocator, "cap_battle.png");
+
     std.time.sleep(5_000_000_000);
-    try device.tap(.RandomMatchBtn);
+    try device.tapAndCapture(.VersusBtn, "cap_versus.png");
+    try describe(allocator, "cap_versus.png");
+
     std.time.sleep(5_000_000_000);
-    try device.tap(.StartMatchBtn);
+    try device.tapAndCapture(.RandomMatchBtn, "cap_random.png");
+    try describe(allocator, "cap_random.png");
+
+    std.time.sleep(5_000_000_000);
+    try device.tapAndCapture(.StartMatchBtn, "cap_start.png");
+    try describe(allocator, "cap_start.png");
 }

--- a/openai.zig
+++ b/openai.zig
@@ -64,10 +64,16 @@ fn chatInternal(
 
         const encoded = base64.standard.Encoder.encode(raw);
 
+        const ext_with_dot = std.fs.path.extension(image_path);
+        const ext = if (ext_with_dot.len > 0 and ext_with_dot[0] == '.')
+            ext_with_dot[1..]
+        else
+            ext_with_dot;
+
         const url_value = try std.fmt.allocPrint(
             allocator,
             "data:image/{s};base64,{s}",
-            .{ std.fs.path.extension(image_path), encoded },
+            .{ ext, encoded },
         );
         defer allocator.free(url_value);
 

--- a/scripts/openai_img_send.py
+++ b/scripts/openai_img_send.py
@@ -10,7 +10,7 @@ import os
 import requests
 
 API_KEY = os.environ["OAI_POKEBOT"]
-API_URL = "https://api.openai.com/v1/responses"
+API_URL = "https://api.openai.com/v1/chat/completions"
 
 local_image_path = "../images/app/solo__adv_battles.png"
 


### PR DESCRIPTION
## Summary
- add `tapAndCapture` helper to `Andy` for tapping and taking screenshots
- describe each captured screenshot with OpenAI in `main.zig`

## Testing
- `python3 -m py_compile scripts/openai_img_send.py`
