### PR TITLE
Centralize config variables in config.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const config_mod = b.createModule(.{
+        .root_source_file = b.path("config.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const andy_mod = b.createModule(.{
         .root_source_file = b.path("src/andy.zig"),
         .target = target,
@@ -25,6 +31,8 @@ pub fn build(b: *std.Build) void {
 
     // Andy depends on ui
     andy_mod.addImport("ui", ui_mod);
+    // Andy depends on config
+    andy_mod.addImport("config", config_mod);
 
     // Main executable module
     const exe_mod = b.createModule(.{
@@ -36,6 +44,7 @@ pub fn build(b: *std.Build) void {
     // Main depends on andy and openai
     exe_mod.addImport("andy", andy_mod);
     exe_mod.addImport("openai", openai_mod);
+    exe_mod.addImport("config", config_mod);
 
     const exe = b.addExecutable(.{
         .name = "pokebot",

--- a/config.zig
+++ b/config.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+pub const api_key_env = "OAI_POKEBOT";
+pub const model_id = "gpt-4o";
+pub const scrcpy_path = "/home/feyd/scrcpy-linux-x86_64-v3.1/scrcpy";
+pub const adb_path = "/usr/bin/adb";

--- a/src/andy.zig
+++ b/src/andy.zig
@@ -1,13 +1,13 @@
 const std = @import("std");
 const ui = @import("ui");
+const config = @import("config");
 
 pub const Andy = struct {
     allocator: std.mem.Allocator,
     scrcpy_process: std.process.Child,
 
     pub fn init(allocator: std.mem.Allocator) !Andy {
-        // TODO: move to config file
-        const scrcpy_path = "/home/feyd/scrcpy-linux-x86_64-v3.1/scrcpy";
+        const scrcpy_path = config.scrcpy_path;
 
         var child = std.process.Child.init(&[_][]const u8{
             scrcpy_path,
@@ -134,8 +134,7 @@ pub const Andy = struct {
         var argv = std.ArrayList([]const u8).init(self.allocator);
         defer argv.deinit();
 
-        // TODO: move to config
-        const adb_path = [_][]const u8{"/usr/bin/adb"};
+        const adb_path = [_][]const u8{config.adb_path};
         try argv.appendSlice(&adb_path);
 
         for (args) |arg| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const andy = @import("andy");
 const openai = @import("openai");
+const config = @import("config");
 
-// TODO: move api_key and model_id to config file
 fn describe(alloc: std.mem.Allocator, api_key: []const u8, model_id: []const u8, path: []const u8) !void {
     // TODO: update this to be dynamic, will change depending on what we need to know
     const question = "What is in the image?";
@@ -17,9 +17,9 @@ pub fn main() !void {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const api_key = std.process.getEnvVarOwned(allocator, "OAI_POKEBOT") catch return error.MissingApiKey;
+    const api_key = std.process.getEnvVarOwned(allocator, config.api_key_env) catch return error.MissingApiKey;
     defer allocator.free(api_key);
-    const model_id = "gpt-4o";
+    const model_id = config.model_id;
 
     var device = try andy.Andy.init(allocator);
     defer device.deinit();


### PR DESCRIPTION
This PR introduces a new configuration file (config.zig) to centralize all configuration variables previously scattered throughout the project. The following changes were made:

- Added config.zig with api_key_env, model_id, scrcpy_path, and adb_path constants
- Updated build.zig to register the config module and link imports in andy and main modules
- Refactored src/main.zig and src/andy.zig to use config constants and removed related TODOs

This improves maintainability and makes it easier to manage configuration in one place.